### PR TITLE
deploy documentation

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -129,3 +129,9 @@ jobs:
     - name: Build documentation
       run: |
         make docs-build
+    - name: Deploy documentation
+      if: github.ref == 'refs/heads/main'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_build/html


### PR DESCRIPTION
@MaceKuailv looks like you've been publishing the documentation manually.
This action should automatically publish on GitHub pages ONLY when you merge into main.
Never used before, so let's see how it goes when you merge.