### PR TITLE
Improve smart read

### DIFF
--- a/ci/environment-ci.yml
+++ b/ci/environment-ci.yml
@@ -3,7 +3,6 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-- dask
 - jupyter-book
 - make
 - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
 - xarray
 - numpy
 - pandas
+- dask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "numpy",
   "pandas",
   "scipy",
+  "dask",
   "xarray"
 ]
 description = "A python package that interpolates data from ocean dataset from both Eulerian and Lagrangian perspective. "

--- a/seaduck/eulerian.py
+++ b/seaduck/eulerian.py
@@ -7,7 +7,7 @@ from seaduck.kernel_weight import KnW, _translate_to_tendency, find_pk_4d
 from seaduck.ocedata import HRel, OceData, RelCoord, TRel, VlRel, VRel
 
 # from OceInterp.kernel_and_weight import _translate_to_tendency,find_pk_4d
-from seaduck.smart_read import smart_read as sread
+from seaduck.smart_read import smart_read
 from seaduck.utils import (
     _general_len,
     find_px_py,
@@ -495,7 +495,7 @@ class Position:
                 "have all the dimensions needed"
             )
         if prefetched is None:
-            return sread(self.ocedata[varName], ind)
+            return smart_read(self.ocedata[varName], ind)
         else:
             return prefetched[ind]
 
@@ -994,7 +994,7 @@ class Position:
                     temp_ind = _subtract_i_min(ind, i_min)
                     needed = np.nan_to_num(prefetched[temp_ind])
                 else:
-                    needed = np.nan_to_num(sread(self.ocedata[varName], ind))
+                    needed = np.nan_to_num(smart_read(self.ocedata[varName], ind))
                 data_lookup[hs] = needed
             elif isinstance(varName, tuple):
                 uname, vname = varName
@@ -1013,10 +1013,10 @@ class Position:
                     vfromu = np.nan_to_num(upre[_subtract_i_min(indvfromu, i_min)])
                     vfromv = np.nan_to_num(vpre[_subtract_i_min(indvfromv, i_min)])
                 else:
-                    ufromu = np.nan_to_num(sread(self.ocedata[uname], indufromu))
-                    ufromv = np.nan_to_num(sread(self.ocedata[vname], indufromv))
-                    vfromu = np.nan_to_num(sread(self.ocedata[uname], indvfromu))
-                    vfromv = np.nan_to_num(sread(self.ocedata[vname], indvfromv))
+                    ufromu = np.nan_to_num(smart_read(self.ocedata[uname], indufromu))
+                    ufromv = np.nan_to_num(smart_read(self.ocedata[vname], indufromv))
+                    vfromu = np.nan_to_num(smart_read(self.ocedata[uname], indvfromu))
+                    vfromv = np.nan_to_num(smart_read(self.ocedata[vname], indvfromv))
                 temp_n_u[bool_ufromu] = ufromu  # 0#
                 temp_n_u[bool_ufromv] = ufromv  # 1#
                 temp_n_v[bool_vfromu] = vfromu  # 0#

--- a/seaduck/smart_read.py
+++ b/seaduck/smart_read.py
@@ -28,6 +28,7 @@ def smart_read(da, indexes_tuple, dask_more_efficient=100):
         )
 
     shape = indexes_tuple[0].shape
+    size = indexes_tuple[0].size
     indexes_tuple = tuple(indexes.ravel() for indexes in indexes_tuple)
 
     if not da.chunks:
@@ -50,10 +51,10 @@ def smart_read(da, indexes_tuple, dask_more_efficient=100):
             if len(block_dict) > dask_more_efficient:
                 return data.vindex[indexes_tuple].compute().reshape(shape)
 
-            if (found_count := found_count + mask.sum()) >= indexes_tuple[0].size:
+            if (found_count := found_count + mask.sum()) == size:
                 break  # all blocks found
 
-    values = np.empty(np.prod(shape))
+    values = np.empty(size)
     for block_ids, (mask, shifted_indexes) in block_dict.items():
         block_values = data.blocks[block_ids].compute()
         values[mask] = block_values[tuple(indexes[mask] for indexes in shifted_indexes)]

--- a/seaduck/smart_read.py
+++ b/seaduck/smart_read.py
@@ -42,10 +42,10 @@ def smart_read(da, indexes_tuple, dask_more_efficient=100):
         mask = True
         for block_id, indexes, chunks in zip(block_ids, indexes_tuple, data.chunks):
             shifted = indexes - sum(chunks[:block_id])
-            shifted_indexes.append(shifted)
             block_mask = (shifted >= 0) & (shifted < chunks[block_id])
             if not block_mask.any() or not (mask := mask & block_mask).any():
                 break  # empty block
+            shifted_indexes.append(shifted)
         else:
             block_dict[block_ids] = (mask, shifted_indexes)
             if len(block_dict) >= dask_more_efficient:

--- a/seaduck/smart_read.py
+++ b/seaduck/smart_read.py
@@ -1,10 +1,7 @@
-from collections import OrderedDict as orderdic
-
 import numpy as np
-import xarray as xr
 
 
-def smart_read(da, ind, memory_chunk=3, xarray_more_efficient=100):
+def smart_read(da, indexes_tuple):
     """Read from a xarray.DataArray given tuple indexes.
 
     Try to do it fast and smartly.
@@ -13,72 +10,43 @@ def smart_read(da, ind, memory_chunk=3, xarray_more_efficient=100):
     ----------
     da: xarray.DataArray
         DataArray to read from
-    ind: tuple of numpy.ndarray
+    indexes_tuple: tuple of numpy.ndarray
         The indexes of points of interest, each element does not need to be 1D
-    memory_chunk: int, default 3
-        If the number of chunks needed is smaller than this, read all of them at once.
-    xarray_more_efficient: int, default 100
-        When the number of chunks is larger than this, and the data points are few,
-        it may make sense to directly use xarray's vectorized read.
 
     Returns
     -------
     + values: numpy.ndarray
-        The values of the points of interest. Has the same shape as the elements in ind.
+        The values of the points of interest. Has the same shape as the elements in indexes_tuple.
     """
-    the_shape = ind[0].shape
-    ind = tuple(i.ravel() for i in ind)
-    if len(da.dims) != len(ind):
-        raise ValueError("index does not match the number of dimensions")
-    if da.chunks is None or da.chunks == {}:
-        npck = np.array(da)
-        return npck[ind].reshape(the_shape)
-    if (
-        np.prod([len(i) for i in da.chunks]) <= memory_chunk
-    ):  # if the number of chunks is small don't bother
-        npck = np.array(da)
-        return npck[ind].reshape(the_shape)
-    cksz = orderdic(zip(da.dims, da.chunks))
-    keys = list(cksz.keys())
-    n = len(ind[0])
-    result = np.zeros(n)
+    if len(indexes_tuple) != da.ndim:
+        raise ValueError(
+            "indexes_tuple does not match the number of dimensions: "
+            f"{len(indexes_tuple)} vs {da.ndim}"
+        )
 
-    new_dic = {}
-    # typically what happens is that the first a few indexes are chunked
-    # here we figure out what is the last dimension chunked.
-    for i in range(len(cksz) - 1, -1, -1):
-        if len(cksz[keys[i]]) > 1:
-            last = i
-            break
-
-    ckbl = np.zeros((n, i + 1)).astype(int)
-    # register each each dimension and the chunk they are in
-    for i, k in enumerate(keys[: i + 1]):
-        ix = ind[i]
-        suffix = np.cumsum(cksz[k])
-        new_dic[i] = suffix
-        ckbl[:, i] = np.searchsorted(suffix, ix, side="right")
-    # this is the time limiting step for localized long query.
-    ckus, inverse = np.unique(ckbl, axis=0, return_inverse=True)
-    # ckus is the individual chunks used
-    if len(ckus) <= xarray_more_efficient:
-        # logging.debug('use smart')
-        for i, k in enumerate(ckus):
-            ind_str = []
-            pre = []
-            which = inverse == i
-            for j, p in enumerate(k):
-                sf = new_dic[j][p]  # the upperbound of index
-                pr = sf - cksz[keys[j]][p]  # the lower bound of index
-                ind_str.append(slice(pr, sf))
-                pre.append(pr)
-            prs = np.zeros(len(keys)).astype(int)
-            prs[: last + 1] = pre
-            npck = np.array(da[tuple(ind_str)])
-            subind = tuple(ind[dim][which] - prs[dim] for dim in range(len(ind)))
-            result[which] = npck[subind]
-        return result.reshape(the_shape)
+    shape = indexes_tuple[0].shape
+    indexes_tuple = tuple(indexes.ravel() for indexes in indexes_tuple)
+    if da.chunks:
+        values = np.empty(indexes_tuple[0].shape)
+        count = 0
+        for block_ids in np.ndindex(*da.data.numblocks):
+            shifted_indexes = []
+            mask = True
+            for block_id, indexes, chunk in zip(
+                block_ids, indexes_tuple, da.data.chunks
+            ):
+                shifted = indexes - sum(chunk[:block_id])
+                shifted_indexes.append(shifted)
+                block_mask = (shifted >= 0) & (shifted < chunk[block_id])
+                if not block_mask.any() or not (mask := mask & block_mask).any():
+                    break
+            else:
+                block_values = da.data.blocks[block_ids].compute()
+                values[mask] = block_values[
+                    tuple(indexes[mask] for indexes in shifted_indexes)
+                ]
+                if (count := count + mask.sum()) >= values.size:
+                    break
     else:
-        # logging.debug('use xarray')
-        xrind = tuple(xr.DataArray(dim, dims=["x"]) for dim in ind)
-        return np.array(da[xrind]).reshape(the_shape)
+        values = da.values[indexes_tuple]
+    return values.reshape(shape)

--- a/seaduck/smart_read.py
+++ b/seaduck/smart_read.py
@@ -1,8 +1,8 @@
 import numpy as np
 
 
-def smart_read(da, indexes_tuple):
-    """Read from a xarray.DataArray given tuple indexes.
+def smart_read(da, indexes_tuple, dask_more_efficient=100):
+    """Read from a xarray.DataArray given a tuple indexes.
 
     Try to do it fast and smartly.
 
@@ -12,6 +12,9 @@ def smart_read(da, indexes_tuple):
         DataArray to read from
     indexes_tuple: tuple of numpy.ndarray
         The indexes of points of interest, each element does not need to be 1D
+    dask_more_efficient: int, default 100
+        When the number of chunks is larger than this, and the data points are few,
+        it may make sense to directly use dask's vectorized read.
 
     Returns
     -------
@@ -26,27 +29,32 @@ def smart_read(da, indexes_tuple):
 
     shape = indexes_tuple[0].shape
     indexes_tuple = tuple(indexes.ravel() for indexes in indexes_tuple)
-    if da.chunks:
-        values = np.empty(indexes_tuple[0].shape)
-        count = 0
-        for block_ids in np.ndindex(*da.data.numblocks):
-            shifted_indexes = []
-            mask = True
-            for block_id, indexes, chunk in zip(
-                block_ids, indexes_tuple, da.data.chunks
-            ):
-                shifted = indexes - sum(chunk[:block_id])
-                shifted_indexes.append(shifted)
-                block_mask = (shifted >= 0) & (shifted < chunk[block_id])
-                if not block_mask.any() or not (mask := mask & block_mask).any():
-                    break
-            else:
-                block_values = da.data.blocks[block_ids].compute()
-                values[mask] = block_values[
-                    tuple(indexes[mask] for indexes in shifted_indexes)
-                ]
-                if (count := count + mask.sum()) >= values.size:
-                    break
-    else:
-        values = da.values[indexes_tuple]
+
+    if not da.chunks:
+        return da.values[indexes_tuple].reshape(shape)
+    data = da.data
+
+    found_count = 0
+    block_dict = {}
+    for block_ids in np.ndindex(*data.numblocks):
+        shifted_indexes = []
+        mask = True
+        for block_id, indexes, chunks in zip(block_ids, indexes_tuple, data.chunks):
+            shifted = indexes - sum(chunks[:block_id])
+            shifted_indexes.append(shifted)
+            block_mask = (shifted >= 0) & (shifted < chunks[block_id])
+            if not block_mask.any() or not (mask := mask & block_mask).any():
+                break  # empty block
+        else:
+            block_dict[block_ids] = (mask, shifted_indexes)
+            if len(block_dict) > dask_more_efficient:
+                return data.vindex[indexes_tuple].compute().reshape(shape)
+
+            if (found_count := found_count + mask.sum()) >= indexes_tuple[0].size:
+                break  # all blocks found
+
+    values = np.empty(np.prod(shape))
+    for block_ids, (mask, shifted_indexes) in block_dict.items():
+        block_values = data.blocks[block_ids].compute()
+        values[mask] = block_values[tuple(indexes[mask] for indexes in shifted_indexes)]
     return values.reshape(shape)

--- a/seaduck/smart_read.py
+++ b/seaduck/smart_read.py
@@ -48,7 +48,7 @@ def smart_read(da, indexes_tuple, dask_more_efficient=100):
                 break  # empty block
         else:
             block_dict[block_ids] = (mask, shifted_indexes)
-            if len(block_dict) > dask_more_efficient:
+            if len(block_dict) >= dask_more_efficient:
                 return data.vindex[indexes_tuple].compute().reshape(shape)
 
             if (found_count := found_count + mask.sum()) == size:

--- a/seaduck/smart_read.py
+++ b/seaduck/smart_read.py
@@ -76,11 +76,11 @@ def smart_read(da, indexes_tuple, dask_more_efficient=100, chunks="auto"):
             )
 
         shifted_indexes = []
-        mask = True
+        mask = None
         for block_id, indexes, chunks in zip(block_ids, indexes_tuple, data.chunks):
             shifted = indexes - sum(chunks[:block_id])
             block_mask = (shifted >= 0) & (shifted < chunks[block_id])
-            if not block_mask.any() or not (mask := mask & block_mask).any():
+            if not (mask := block_mask if mask is None else mask & block_mask).any():
                 break  # empty block
             shifted_indexes.append(shifted)
         else:

--- a/seaduck/smart_read.py
+++ b/seaduck/smart_read.py
@@ -16,7 +16,7 @@ def slice_data_and_shift_indexes(da, indexes_tuple):
     return da.data[slicers], indexes_tuple
 
 
-def smart_read(da, indexes_tuple, dask_more_efficient=100, chunks="auto"):
+def smart_read(da, indexes_tuple, dask_more_efficient=10, chunks="auto"):
     """Read from a xarray.DataArray given a tuple indexes.
 
     Try to do it fast and smartly.

--- a/tests/test_smart_read.py
+++ b/tests/test_smart_read.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from seaduck.smart_read import smart_read as srd
+from seaduck.smart_read import smart_read
 
 
 @pytest.fixture
@@ -19,16 +19,16 @@ def ind():
 @pytest.mark.parametrize("ds", ["ecco"], indirect=True)
 def test_just_read(ind, ds, chunk):
     ds["SALT"] = ds["SALT"].chunk(chunk)
-    srd(ds["SALT"], ind)
+    smart_read(ds["SALT"], ind)
 
 
 @pytest.mark.parametrize("ds", ["ecco"], indirect=True)
 def test_read_xarray(ind, ds):
     ds["SALT"] = ds["SALT"].chunk({"time": 1})
-    srd(ds["SALT"], ind, dask_more_efficient=1)
+    smart_read(ds["SALT"], ind, dask_more_efficient=1)
 
 
 @pytest.mark.parametrize("ds", ["ecco"], indirect=True)
 def test_mismatch_read(ind, ds):
     with pytest.raises(ValueError):
-        srd(ds["XC"], ind)
+        smart_read(ds["XC"], ind)

--- a/tests/test_smart_read.py
+++ b/tests/test_smart_read.py
@@ -25,7 +25,7 @@ def test_just_read(ind, ds, chunk):
 @pytest.mark.parametrize("ds", ["ecco"], indirect=True)
 def test_read_xarray(ind, ds):
     ds["SALT"] = ds["SALT"].chunk({"time": 1})
-    srd(ds["SALT"], ind, xarray_more_efficient=1)
+    srd(ds["SALT"], ind, dask_more_efficient=1)
 
 
 @pytest.mark.parametrize("ds", ["ecco"], indirect=True)


### PR DESCRIPTION
This `smart_read` function is very interesting, a played a little with it today.

Here is an alternative implementation. I removed `memory_chunk` because it looks a little risky: What happen if you have large chunks? You can get the same behavior by passing `da.compute()` rather than `da`.

It would be nice to parametrise a little better the switch that controls the use of vectorised indexing, but I wouldn't know how to do it :)

Even if you don't merge this, I suggest to improve a little the docstring explaining what's going on. `Try to do it fast and smartly.` is not very helpful, try to explain the idea behind this function.

Here is a quick and dirty benchmark, it would be nice to test with real data, maybe this is just optimised for this specific case:
```python
import oceanspy as ospy
import numpy as np

od = ospy.open_oceandataset.from_catalog("HYCOM")
da = od._ds.Eta

size = 100000
indexes_tuple = tuple(np.random.randint(n, size=100000) for n in (5, 1251, 701))
```

```python
%timeit old_smart_read(da, indexes_tuple)
%timeit new_smart_read(da, indexes_tuple)
np.testing.assert_equal(
    old_smart_read(da, indexes_tuple), new_smart_read(da, indexes_tuple)
)
```

    275 ms ± 5.98 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
    99.9 ms ± 5.74 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

```python
da = da.chunk(100)
assert np.prod(da.data.numblocks) > 100
%timeit old_smart_read(da, indexes_tuple)
%timeit new_smart_read(da, indexes_tuple)
np.testing.assert_equal(
    old_smart_read(da, indexes_tuple), new_smart_read(da, indexes_tuple)
)
```

    3.17 s ± 140 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
    3.13 s ± 179 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
