### PR TITLE
fix links and renew sciserver notebooks after 1.0.0

### DIFF
--- a/docs/contribute/contr_doc.md
+++ b/docs/contribute/contr_doc.md
@@ -53,7 +53,7 @@ Now, run it again. If this time it still has an error, look at the error message
 
 Cool stuff are not always portable. The ocean 🌊 is an example of that.
 Say you have something really cool you want to demonstrate, but the dataset it is based on is to large to distribute or it simply takes too long to run. Wouldn't it be nice if we could have a cloud platform that host a bunch of ocean dataset that is free for everyone to use? It would be even better if the packages I need as an oceanographer is readily installed and I don't have to worry about a thing.
-You can use [Sciserver](https://sciserver.org/)! (Am I too dramatic?). Sciserver is also the home base of [oceanspy](https://oceanspy.readthedocs.io/en/latest/), a package that will make your life so much easier as a oceanographer. After registering on sciserver (you can follow this youtube tutorial here(Tom, if you are reading this, can you send me the link?)), you can simply call this oceanspy function
+You can use [Sciserver](https://sciserver.org/)! (Am I too dramatic?). Sciserver is also the home base of [oceanspy](https://oceanspy.readthedocs.io/en/latest/), a package that will make your life so much easier as a oceanographer. After registering on sciserver (you can follow this youtube tutorial [here](https://www.youtube.com/channel/UCpYkjUrm2a_ANY86Fb4uyvg)), you can simply call this oceanspy function
 
 ```python
 import ocenspy as ospy
@@ -97,14 +97,10 @@ git clone https://github.com/YourGithubNickname/seaduck_sciserver_notebook.git
 ```
 
 All the existing sciserver notebooks will be in `seaduck_sciserver_notebook`. If you want to create new ones, put them in there as well.
-2\. Have all the fun with your notebooks. However, whenever you plot, **always** use `plt.show()`.
-3\. Install `Jupytext` for converting notebooks into markdown.
 
-```shell
-pip install jupytext
-```
+2. Have all the fun with your notebooks. However, whenever you plot, **always** use `plt.show()`.
 
-4\. In `seaduck_sciserver_notebook`, run the python script
+3. In `seaduck_sciserver_notebook`, run the python script
 
 ```shell
 python convert_ipynb.py
@@ -112,14 +108,14 @@ python convert_ipynb.py
 
 > This step will add when and which version the notebook was last run on. It will search the file with the string **Wenrui Jiang** (How egoistic?!), and put the information in the next line. It is a bit ad hoc. If I am not the author of the notebook, simply include: "Wenrui Jiang is a good boy" or something like that after putting your name.
 
-5. You will realize that the markdown files created may not be able to render properly. This is because the new plots you have are local, but the link we put in the markdown files are what they would look like if the plots are already uploaded. Now, commit all the changes and make a pull request to the `seaduck_sciserver_notebook` repo. Once the changes are merged into the `main` branch. Open the file and see if it look as you intended. If so,
+4. You will realize that the markdown files created may not be able to render properly. This is because the new plots you have are local, but the link we put in the markdown files are what they would look like if the plots are already uploaded. Now, commit all the changes and make a pull request to the `seaduck_sciserver_notebook` repo. Once the changes are merged into the `main` branch. Open the file and see if it look as you intended. If so,
 
 ```shell
 cp *.md ../seaduck/docs/sciserver_notebooks/
 ```
 
-6. Change directory back to seaduck. Follow step 4 to 7 in the [previous](text_file) section.
-1. Before the changes are merged, check if the external links work by
+5. Change directory back to seaduck. Follow step 4 to 7 in the [previous](text_file) section.
+6. Before the changes are merged, check if the external links work by
 
 ```shell
 make link-check

--- a/docs/contribute/contr_doc.md
+++ b/docs/contribute/contr_doc.md
@@ -100,7 +100,7 @@ All the existing sciserver notebooks will be in `seaduck_sciserver_notebook`. If
 
 2. Have all the fun with your notebooks. However, whenever you plot, **always** use `plt.show()`.
 
-3. In `seaduck_sciserver_notebook`, run the python script
+1. In `seaduck_sciserver_notebook`, run the python script
 
 ```shell
 python convert_ipynb.py
@@ -115,7 +115,7 @@ cp *.md ../seaduck/docs/sciserver_notebooks/
 ```
 
 5. Change directory back to seaduck. Follow step 4 to 7 in the [previous](text_file) section.
-6. Before the changes are merged, check if the external links work by
+1. Before the changes are merged, check if the external links work by
 
 ```shell
 make link-check

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -29,6 +29,7 @@ Running Lagrangian particle on regional dataset
 
 Example with complex grid (LLC4320)
 ^^^
+
 ```{image} https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/stable_images/LLC4320Thumbnail.png?raw=true
 :height: 200
 ```

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -23,14 +23,16 @@ Running Lagrangian particle on regional dataset
 :::
 
 :::{grid-item-card}
-:link: sciserver_notebooks/IGPwinter
+:link: sciserver_notebooks/LLC4320
 :link-type: doc
 :class-header: bg-light
 
-Example with complex grid
+Example with complex grid (LLC4320)
 ^^^
+```{image} https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/stable_images/LLC4320Thumbnail.png?raw=true
+:height: 200
+```
 
-Running Lagrangian particle on the LLC4320 dataset.
 :::
 
 :::{grid-item-card}

--- a/docs/sciserver_notebooks/ECCO_plot_stations.md
+++ b/docs/sciserver_notebooks/ECCO_plot_stations.md
@@ -18,7 +18,7 @@ Extract temperature/salinity profiles at specified longitudes, latitudes, and ti
 This notebook uses [Oceanspy](https://oceanspy.readthedocs.io/en/latest/) and demonstrates the interface to the Poseidon-viewer on SciServer.
 
 Author: Tom Haine & Wenrui Jiang, Jun '23
-> **Warning**⚠️ : the notebook was last ran on **2023-07-27** with **seaduck 0.1.3**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/ECCO_plot_stations.ipynb.
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/ECCO_plot_stations.ipynb. 
 ```{code-cell} ipython3
 import seaduck as sd
 import oceanspy as ospy
@@ -31,7 +31,7 @@ plt.rcParams["figure.figsize"] = 12, 8
 ```
 
 ```{admonition} Access ECCO
-The global MITgcm run is the ECCO state estimate [(Forget et al, 2015)](https://gmd.copernicus.org/articles/8/3071/2015/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html#) method.
+The global MITgcm run is the ECCO state estimate [(Forget et al, 2015)](https://gmd.copernicus.org/articles/8/3071/2015/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method. 
 
 `ecco = ospy.open_oceandataset.from_catalog("ECCO")`
 

--- a/docs/sciserver_notebooks/ECCO_plot_stations.md
+++ b/docs/sciserver_notebooks/ECCO_plot_stations.md
@@ -18,7 +18,7 @@ Extract temperature/salinity profiles at specified longitudes, latitudes, and ti
 This notebook uses [Oceanspy](https://oceanspy.readthedocs.io/en/latest/) and demonstrates the interface to the Poseidon-viewer on SciServer.
 
 Author: Tom Haine & Wenrui Jiang, Jun '23
-> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/ECCO_plot_stations.ipynb. 
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/ECCO_plot_stations.ipynb.
 ```{code-cell} ipython3
 import seaduck as sd
 import oceanspy as ospy
@@ -31,7 +31,7 @@ plt.rcParams["figure.figsize"] = 12, 8
 ```
 
 ```{admonition} Access ECCO
-The global MITgcm run is the ECCO state estimate [(Forget et al, 2015)](https://gmd.copernicus.org/articles/8/3071/2015/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method. 
+The global MITgcm run is the ECCO state estimate [(Forget et al, 2015)](https://gmd.copernicus.org/articles/8/3071/2015/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method.
 
 `ecco = ospy.open_oceandataset.from_catalog("ECCO")`
 

--- a/docs/sciserver_notebooks/IGPwinter.md
+++ b/docs/sciserver_notebooks/IGPwinter.md
@@ -14,7 +14,7 @@ kernelspec:
 # `Particle` in an East Greenland regional simulation
 
 Author: Wenrui Jiang, Tom Haine Feb '23
-> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/IGPwinter.ipynb. 
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/IGPwinter.ipynb.
 ```{code-cell} ipython3
 :tags: [hide-input]
 
@@ -26,7 +26,7 @@ import seaduck as sd
 ```
 
 ```{admonition} Access IGPwinter
-The regional MITgcm run is the IGPwinter simulation [( Renfrew et al., 2019)](https://journals.ametsoc.org/view/journals/bams/100/9/bams-d-18-0217.1.xml) and is publicly available on [SciServer](https://sciserver.org/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method. 
+The regional MITgcm run is the IGPwinter simulation [( Renfrew et al., 2019)](https://journals.ametsoc.org/view/journals/bams/100/9/bams-d-18-0217.1.xml) and is publicly available on [SciServer](https://sciserver.org/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method.
 
 `ecco = ospy.open_oceandataset.from_catalog("IGPwinter")`
 

--- a/docs/sciserver_notebooks/IGPwinter.md
+++ b/docs/sciserver_notebooks/IGPwinter.md
@@ -14,7 +14,7 @@ kernelspec:
 # `Particle` in an East Greenland regional simulation
 
 Author: Wenrui Jiang, Tom Haine Feb '23
-> **Warning**⚠️ : the notebook was last ran on **2023-07-27** with **seaduck 0.1.3**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/IGPwinter.ipynb.
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/IGPwinter.ipynb. 
 ```{code-cell} ipython3
 :tags: [hide-input]
 
@@ -26,7 +26,7 @@ import seaduck as sd
 ```
 
 ```{admonition} Access IGPwinter
-The regional MITgcm run is the IGPwinter simulation [( Renfrew et al., 2019)](https://journals.ametsoc.org/view/journals/bams/100/9/bams-d-18-0217.1.xml) and is publicly available on [SciServer](https://sciserver.org/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html#) method.
+The regional MITgcm run is the IGPwinter simulation [( Renfrew et al., 2019)](https://journals.ametsoc.org/view/journals/bams/100/9/bams-d-18-0217.1.xml) and is publicly available on [SciServer](https://sciserver.org/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method. 
 
 `ecco = ospy.open_oceandataset.from_catalog("IGPwinter")`
 

--- a/docs/sciserver_notebooks/KangerFjord.md
+++ b/docs/sciserver_notebooks/KangerFjord.md
@@ -14,7 +14,7 @@ kernelspec:
 # Demonstrate `eulerian.Position` object with Fjord
 
 Author: Wenrui Jiang, 14 June 2023
-> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord.ipynb. 
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord.ipynb.
 The `eulerian.Position` object is really what connects a point and the numerical model. Its `interpolate` method really is the core of this package. We're going to use a rather interesting example to demonstrate the functionalities of `eulerian.Position`.
 
 ```{code-cell} ipython3
@@ -90,7 +90,7 @@ plt.show()
 +++ {"tags": ["mdformat-skip"]}
 
 ## Doing Interpolation
-We are going to use the sea surface height field $\eta$ as an example. 
+We are going to use the sea surface height field $\eta$ as an example.
 
 First, we are going to convert the `xarray.Dataset` to `seaduck.OceData`.
 

--- a/docs/sciserver_notebooks/KangerFjord.md
+++ b/docs/sciserver_notebooks/KangerFjord.md
@@ -14,7 +14,7 @@ kernelspec:
 # Demonstrate `eulerian.Position` object with Fjord
 
 Author: Wenrui Jiang, 14 June 2023
-> **Warning**⚠️ : the notebook was last ran on **2023-07-27** with **seaduck 0.1.3**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord.ipynb.
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord.ipynb. 
 The `eulerian.Position` object is really what connects a point and the numerical model. Its `interpolate` method really is the core of this package. We're going to use a rather interesting example to demonstrate the functionalities of `eulerian.Position`.
 
 ```{code-cell} ipython3
@@ -30,7 +30,7 @@ import cmocean
 mpl.rcParams["figure.dpi"] = 300
 ```
 
-Here on [SciServer](https://sciserver.org/), we have an interesting dataset simulating the interaction between background circulation and Kangerdlugssuaq Fjord. More information can be found below, and see the paper by [Fraser et al., 2018](https://doi.org/10.1029/2018JC014435)
+Here on [SciServer](https://sciserver.org/), we have an interesting dataset simulating the interaction between background circulation and Kangerdlugssuaq Fjord. More information can be found below, and see the paper by [Fraser et al., 2018](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2018JC014435):
 
 ```{code-cell} ipython3
 fjord = ospy.open_oceandataset.from_catalog("KangerFjord")
@@ -85,12 +85,12 @@ plt.ylabel("Latitude")
 plt.colorbar(c, label="m")
 plt.show()
 ```
-![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/Fjord_8_0.png?raw=true)
+![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/KangerFjord_8_0.png?raw=true)
 
 +++ {"tags": ["mdformat-skip"]}
 
 ## Doing Interpolation
-We are going to use the sea surface height field $\eta$ as an example.
+We are going to use the sea surface height field $\eta$ as an example. 
 
 First, we are going to convert the `xarray.Dataset` to `seaduck.OceData`.
 
@@ -140,7 +140,7 @@ plt.xlabel("Longitude")
 plt.ylabel("Latitude")
 plt.show()
 ```
-![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/Fjord_19_0.png?raw=true)
+![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/KangerFjord_19_0.png?raw=true)
 
 Now let's "hack" the code to make it return the size of the kernels used.
 
@@ -181,7 +181,7 @@ plt.xlabel("Longitude")
 plt.ylabel("Latitude")
 plt.show()
 ```
-![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/Fjord_24_0.png?raw=true)
+![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/KangerFjord_24_0.png?raw=true)
 
 ## Filling between
 
@@ -218,6 +218,6 @@ plt.xlabel("Longitude")
 plt.ylabel("Latitude")
 plt.show()
 ```
-![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/Fjord_29_0.png?raw=true)
+![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/KangerFjord_files/KangerFjord_29_0.png?raw=true)
 
 I'd say the filling-in is done pretty well!

--- a/docs/sciserver_notebooks/LLC4320.md
+++ b/docs/sciserver_notebooks/LLC4320.md
@@ -14,7 +14,7 @@ kernelspec:
 # Plot surface streamlines on LLC4320
 
 Author: Wenrui Jiang 14 June, 2023
-> **Warning**⚠️ : the notebook was last ran on **2023-07-27** with **seaduck 0.1.3**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320.ipynb.
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320.ipynb. 
 The LLC4320 ocean circulation model solution is a kilometer-scale, global simulation with complex grid topology. This is a good dataset to test the performance of the `seaduck` package.
 
 ```{code-cell} ipython3
@@ -33,7 +33,7 @@ mpl.rcParams["figure.dpi"] = 600
 
 ```{admonition} Access LLC4320
 The global MITgcm run is the LLC4320 simulation [(Rocha
-et al. 2016)](https://journals.ametsoc.org/view/journals/phoc/46/2/jpo-d-15-0087.1.xmlhttps://journals.ametsoc.org/view/journals/phoc/46/2/jpo-d-15-0087.1.xml) and is publicly available on [SciServer](https://sciserver.org) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html#oceanspy.open_oceandataset.from_catalog) method.
+et al. 2016)](https://journals.ametsoc.org/view/journals/phoc/46/2/jpo-d-15-0087.1.xml) and is publicly available on [SciServer](https://sciserver.org/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method. 
 
 `od = ospy.open_oceandataset.from_catalog("LLC4320")`
 
@@ -52,7 +52,7 @@ ds = od._ds
 oce = sd.OceData(ds)
 ```
 
-Initiate the particles randomly, so that they're distributed evenly on the globe. Use `N` = $1.5 \\times 10^5$ particles.
+Initiate the particles randomly, so that they're distributed evenly on the globe. Use $N = 1.5 \\times 10^5$ particles.
 
 ```{code-cell} ipython3
 :tags: [hide-input]
@@ -75,7 +75,7 @@ ax.plot(x, y, "o", markersize=0.1, transform=ccrs.PlateCarree())
 ax.coastlines()
 plt.show()
 ```
-![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320_files/LLC4320_5_0.png?raw=true)
+![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320_files/LLC4320_6_0.png?raw=true)
 
 We'll use just one vertical layer (the first one, which is at the surface) of a single snapshot (the first one) to make the streamlines.
 
@@ -250,7 +250,7 @@ pretty_stream_plot(
 )
 plt.show()
 ```
-![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320_files/LLC4320_29_2.png?raw=true)
+![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320_files/LLC4320_30_2.png?raw=true)
 
 **Fig.1** Streamlines of 150,000 particles released at 00:00 Apr 25, 2012 in LLC4320 simulated for 30 days. The color shading shows the current speed. This is looking from the North Pole.
 
@@ -270,6 +270,6 @@ pretty_stream_plot(
 )
 plt.show()
 ```
-![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320_files/LLC4320_32_2.png?raw=true)
+![png](https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320_files/LLC4320_33_2.png?raw=true)
 
 **Fig.2** Similar to **Fig.1**, but looking from the South Pole.

--- a/docs/sciserver_notebooks/LLC4320.md
+++ b/docs/sciserver_notebooks/LLC4320.md
@@ -14,7 +14,7 @@ kernelspec:
 # Plot surface streamlines on LLC4320
 
 Author: Wenrui Jiang 14 June, 2023
-> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320.ipynb. 
+> **Warning**⚠️ : the notebook was last ran on **2023-11-22** with **seaduck 1.0.0**. You can find the executable version at https://github.com/MaceKuailv/seaduck_sciserver_notebook/blob/master/LLC4320.ipynb.
 The LLC4320 ocean circulation model solution is a kilometer-scale, global simulation with complex grid topology. This is a good dataset to test the performance of the `seaduck` package.
 
 ```{code-cell} ipython3
@@ -33,7 +33,7 @@ mpl.rcParams["figure.dpi"] = 600
 
 ```{admonition} Access LLC4320
 The global MITgcm run is the LLC4320 simulation [(Rocha
-et al. 2016)](https://journals.ametsoc.org/view/journals/phoc/46/2/jpo-d-15-0087.1.xml) and is publicly available on [SciServer](https://sciserver.org/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method. 
+et al. 2016)](https://journals.ametsoc.org/view/journals/phoc/46/2/jpo-d-15-0087.1.xml) and is publicly available on [SciServer](https://sciserver.org/) (from the Oceanography container). The simulation output can be opened using the [OceanSpy](https://github.com/hainegroup/oceanspy) package using the [`from_catalog`](https://oceanspy.readthedocs.io/en/latest/generated/oceanspy.open_oceandataset.from_catalog.html) method.
 
 `od = ospy.open_oceandataset.from_catalog("LLC4320")`
 


### PR DESCRIPTION
This is to address #97. 

We are also updating the documentation after running every sciserver notebook after v1.0.0. The result: absolutely no difference. 