### PR TITLE
Add Lagrangian budget dataset to zenodo

### DIFF
--- a/docs/budget_tutorial/particle_bud_tut.ipynb
+++ b/docs/budget_tutorial/particle_bud_tut.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_zarr('lag_budg.zarr')"
+    "ds = sd.utils.get_dataset('lag_budg')"
    ]
   },
   {
@@ -707,7 +707,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (seaduck-docs)",
    "language": "python",
    "name": "python3"
   },
@@ -721,7 +721,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/seaduck/utils.py
+++ b/seaduck/utils.py
@@ -21,11 +21,11 @@ except ImportError:
 
 
 @functools.cache
-def pooch_prepare(run_budget=False):
+def pooch_prepare(dataset_name=""):
     """Prepare for loading datasets using pooch."""
     doi = "10.5281/zenodo.15884732"
-    if run_budget:
-        doi = "10.5281/zenodo.18675196"
+    if dataset_name in ("eul_bud_mean", "lag_budg"):
+        doi = "10.5281/zenodo.21536496"
     pooch_testdata = pooch.create(
         path=pooch.os_cache("seaduck"),
         base_url=f"doi:{doi}",
@@ -114,11 +114,9 @@ def get_dataset(name):
     Parameters
     ----------
     name: string
-        The name of dataset, now support "ecco", "aviso", "curv", "rect", "aste", "eul_bud_mean"
+        The name of dataset, now support "ecco", "aviso", "curv", "rect", "aste", "eul_bud_mean", "lag_budg"
     """
-    pooch_testdata, pooch_fetch_kwargs = pooch_prepare(
-        run_budget=(name == "eul_bud_mean")
-    )
+    pooch_testdata, pooch_fetch_kwargs = pooch_prepare(dataset_name=name)
     fnames = pooch_testdata.fetch(f"{name}.tar.gz", pooch.Untar(), **pooch_fetch_kwargs)
     ds = xr.open_zarr(os.path.commonpath(fnames))
     if name == "ecco":


### PR DESCRIPTION
After the documentation upgrade, part of the problem is that all the notebook seems to be running at the same time. The Lagrangian budget notebook used to need output from the Eulerian budget notebook. Now I uploaded the resulting dataset to zenodo to avoid this problem. 